### PR TITLE
fix: change last commit badge from master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rbase
 Rust setup for new project
 
-[![GitHub last commit](https://img.shields.io/github/last-commit/lsh0x/rbase)](https://github.com/lsh0x/rbase/commits/master)
+[![GitHub last commit](https://img.shields.io/github/last-commit/lsh0x/rbase)](https://github.com/lsh0x/rbase/commits/main)
 [![CI](https://github.com/lsh0x/rbase/workflows/CI/badge.svg)](https://github.com/lsh0x/rbase/actions)
 [![Codecov](https://codecov.io/gh/lsh0x/rbase/branch/main/graph/badge.svg)](https://codecov.io/gh/lsh0x/rbase)
 [![Docs](https://docs.rs/rbase/badge.svg)](https://docs.rs/rbase)


### PR DESCRIPTION
### Pull Request Title: Update Badge to Reflect Branch Renaming

#### Description:

This pull request addresses a minor but important change in the project's CI and README setup:

- **Modify Badge Reference**: The commit `fix: change last commit badge from master to main` updates the build status badge to reference the `main` branch instead of the outdated `master` branch. This change ensures that status indicators are aligned with current GitHub branch naming conventions.

#### Impact:

- Accurately displays build and test status for the `main` branch, improving project transparency and monitoring.

#### Notes:

- No functional changes to the codebase; this purely updates documentation-related assets.

Please review the change and confirm that all documentation references comply with the new branch naming standards