### PR TITLE
fix: libsso prob du latest ubuntu

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   cover:
     name: Auto Codecov Coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout Repository
@@ -24,9 +24,7 @@ jobs:
           version: '0.15.0'
           args: '-- --test-threads 1'
 
-
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
-
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbase"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["LSH <github@lsh.tech>"]
 edition = "2021"
 description = "Github template to setup the CI and cargo publish"


### PR DESCRIPTION
# Fix: Install libSSO for Codecov

## Description
This PR resolves an issue where `libSSO` was missing, causing Codecov to fail. It adds the installation of `libSSO` to the setup to ensure smooth integration with Codecov.

## Changes
- Added installation of `libSSO` in the setup script for Codecov.

## How to Verify
1. Ensure that `libSSO` is now installed during the setup.
2. Run the Codecov process and verify that there are no errors related to missing libraries.