### PR TITLE
fix: cron for sync template

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -1,7 +1,9 @@
+name: Sync rbase
+
 on:
   # cronjob trigger
   schedule:
-  - cron: "0 0 0 0 1"
+  - cron: "0 0 * * *"
   # manual trigger
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
# Pull Request: Fix Template Sync Cron Configuration

## Summary

This PR fixes the cron expression in the template synchronization workflow. The previous expression `"0 0 0 0 1"` was invalid and would not trigger as expected. The corrected expression `"0 0 * * *"` will run the synchronization job at midnight every day.

## Commit History

* ad92f8d - fix: cron for sync template

## Technical Details

The GitHub Actions workflow file `.github/workflows/template-sync.yml` has been updated to use a valid cron expression:

diff
This change ensures our template synchronization will run as scheduled, keeping our repository in sync with the base template.
